### PR TITLE
test: performance test for undertow

### DIFF
--- a/solon_undertow/README-20240815-songdragon.md
+++ b/solon_undertow/README-20240815-songdragon.md
@@ -1,0 +1,102 @@
+**硬件环境**
+MacBook Pro 2019
+CPU: Intel Core i7 六核 2.6GHz
+内存: 16GB 2667 MHz DDR4
+macOS: Sonoma 14.5
+
+**软件环境**
+openjdk version "20" 2023-03-21
+OpenJDK Runtime Environment (build 20+36-2344)
+OpenJDK 64-Bit Server VM (build 20+36-2344, mixed mode, sharing)
+
+**测试方法**
+1. 编译完成后，命令行启动
+2. 使用wrk进行压测
+
+** 启动后内存 **
+``` shell
+ps -p 9384 -o pid,args,rss,vsz                                             
+PID ARGS                            RSS      VSZ
+9384 java -jar solon_undertow.jar  41888 40165304
+```
+
+**第一次**
+
+```
+$ wrk -t10 -c200 -d30s --latency "http://127.0.0.1:8080/"
+Running 30s test @ http://127.0.0.1:8080/
+  10 threads and 200 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency    15.94ms   48.01ms   1.24s    93.19%
+    Req/Sec     5.68k     2.79k   24.46k    73.32%
+  Latency Distribution
+     50%    2.38ms
+     75%    7.32ms
+     90%   38.60ms
+     99%  221.84ms
+  1324256 requests in 30.09s, 260.16MB read
+  Socket errors: connect 0, read 347, write 0, timeout 2
+Requests/sec:  44010.19
+Transfer/sec:      8.65MB
+```
+
+**第二次**
+
+```
+$ wrk -t10 -c200 -d30s --latency "http://127.0.0.1:8080/"
+Running 30s test @ http://127.0.0.1:8080/
+  10 threads and 200 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     6.39ms   22.40ms 906.77ms   96.27%
+    Req/Sec     6.53k     1.99k   28.16k    80.53%
+  Latency Distribution
+     50%    2.43ms
+     75%    3.32ms
+     90%    9.74ms
+     99%   88.31ms
+  1568045 requests in 30.09s, 308.05MB read
+  Socket errors: connect 0, read 290, write 0, timeout 2
+Requests/sec:  52118.13
+Transfer/sec:     10.24MB
+```
+
+**第三次**
+
+```
+$ wrk -t10 -c200 -d30s --latency "http://127.0.0.1:8080/"
+Running 30s test @ http://127.0.0.1:8080/
+  10 threads and 200 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency    11.11ms   53.48ms   1.66s    97.03%
+    Req/Sec     6.37k     2.17k   25.06k    81.69%
+  Latency Distribution
+     50%    2.44ms
+     75%    3.75ms
+     90%   11.03ms
+     99%  242.07ms
+  1641788 requests in 30.09s, 322.54MB read
+  Socket errors: connect 0, read 463, write 0, timeout 0
+Requests/sec:  54561.18
+Transfer/sec:     10.72MB
+```
+
+**第四次**
+
+```
+$ wrk -t10 -c200 -d30s --latency "http://127.0.0.1:8080/"
+Running 30s test @ http://127.0.0.1:8080/
+  10 threads and 200 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency    25.10ms  107.18ms   1.07s    95.75%
+    Req/Sec     6.15k     2.31k   30.99k    79.80%
+  Latency Distribution
+     50%    2.45ms
+     75%    4.25ms
+     90%   19.12ms
+     99%  697.77ms
+  1358780 requests in 30.08s, 266.94MB read
+  Socket errors: connect 0, read 294, write 0, timeout 2
+Requests/sec:  45179.20
+Transfer/sec:      8.88MB
+
+```

--- a/springboot_undertow/README-20240815_noauto_songdragon.md
+++ b/springboot_undertow/README-20240815_noauto_songdragon.md
@@ -1,0 +1,101 @@
+**硬件环境**
+MacBook Pro 2019
+CPU: Intel Core i7 六核 2.6GHz
+内存: 16GB 2667 MHz DDR4
+macOS: Sonoma 14.5
+
+**软件环境**
+openjdk version "20" 2023-03-21
+OpenJDK Runtime Environment (build 20+36-2344)
+OpenJDK 64-Bit Server VM (build 20+36-2344, mixed mode, sharing)
+
+**测试方法**
+1. 编译完成后，命令行启动
+2. 使用wrk进行压测
+
+** 启动后内存 **
+``` shell
+ps -p 26561  -o pid,args,rss,vsz                                      
+  PID ARGS                                 RSS      VSZ
+26561 java -jar springboot_undertow.jar 136788 40168988
+```
+
+**第一次**
+
+``` shell
+$ wrk -t10 -c200 -d30s --latency "http://127.0.0.1:8080/"
+Running 30s test @ http://127.0.0.1:8080/
+  10 threads and 200 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency    27.37ms   51.48ms 763.44ms   87.43%
+    Req/Sec     4.43k     3.64k   28.51k    75.78%
+  Latency Distribution
+     50%    1.27ms
+     75%   31.09ms
+     90%   94.28ms
+     99%  235.68ms
+  1065387 requests in 30.12s, 164.60MB read
+  Socket errors: connect 0, read 292, write 0, timeout 1
+Requests/sec:  35377.05
+Transfer/sec:      5.47MB
+```
+
+**第二次**
+
+```
+$ wrk -t10 -c200 -d30s --latency "http://127.0.0.1:8080/"
+Running 30s test @ http://127.0.0.1:8080/
+  10 threads and 200 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     5.26ms   24.19ms 938.23ms   98.82%
+    Req/Sec     6.40k     1.57k   22.19k    83.38%
+  Latency Distribution
+     50%    2.44ms
+     75%    3.21ms
+     90%    7.35ms
+     99%   32.11ms
+  1515803 requests in 30.10s, 234.18MB read
+  Socket errors: connect 0, read 296, write 0, timeout 2
+Requests/sec:  50361.88
+Transfer/sec:      7.78MB
+```
+
+**第三次**
+
+```
+$ wrk -t10 -c200 -d30s --latency "http://127.0.0.1:8080/"
+Running 30s test @ http://127.0.0.1:8080/
+  10 threads and 200 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     4.99ms   22.05ms 991.51ms   98.76%
+    Req/Sec     6.62k     1.52k   25.75k    83.45%
+  Latency Distribution
+     50%    2.41ms
+     75%    3.08ms
+     90%    7.00ms
+     99%   31.70ms
+  1620797 requests in 30.09s, 250.41MB read
+  Socket errors: connect 0, read 293, write 0, timeout 2
+Requests/sec:  53862.74
+Transfer/sec:      8.32MB
+```
+
+**第四次**
+
+```
+$ wrk -t10 -c200 -d30s --latency "http://127.0.0.1:8080/"
+Running 30s test @ http://127.0.0.1:8080/
+  10 threads and 200 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     5.13ms   21.40ms 992.71ms   98.01%
+    Req/Sec     6.78k     1.74k   23.43k    87.34%
+  Latency Distribution
+     50%    2.38ms
+     75%    3.01ms
+     90%    6.99ms
+     99%   51.26ms
+  1635456 requests in 30.10s, 252.67MB read
+  Socket errors: connect 0, read 293, write 0, timeout 2
+Requests/sec:  54335.43
+Transfer/sec:      8.39MB
+```

--- a/springboot_undertow/README-20240815_original_songdragon.md
+++ b/springboot_undertow/README-20240815_original_songdragon.md
@@ -1,0 +1,101 @@
+**硬件环境**
+MacBook Pro 2019
+CPU: Intel Core i7 六核 2.6GHz
+内存: 16GB 2667 MHz DDR4
+macOS: Sonoma 14.5
+
+**软件环境**
+openjdk version "20" 2023-03-21
+OpenJDK Runtime Environment (build 20+36-2344)
+OpenJDK 64-Bit Server VM (build 20+36-2344, mixed mode, sharing)
+
+**测试方法**
+1. 编译完成后，命令行启动
+2. 使用wrk进行压测
+
+** 启动后内存 **
+``` shell
+ps -p 15689 -o pid,args,rss,vsz                                           
+  PID ARGS                                 RSS      VSZ
+15689 java -jar springboot_undertow.jar 151308 40167376
+```
+
+**第一次**
+
+``` shell
+$ wrk -t10 -c200 -d30s --latency "http://127.0.0.1:8080/"
+Running 30s test @ http://127.0.0.1:8080/
+  10 threads and 200 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency    35.79ms   64.65ms   1.01s    86.57%
+    Req/Sec     4.16k     3.75k   22.72k    72.94%
+  Latency Distribution
+     50%    0.96ms
+     75%   47.22ms
+     90%  124.20ms
+     99%  273.18ms
+  958066 requests in 30.10s, 143.45MB read
+  Socket errors: connect 0, read 301, write 0, timeout 2
+Requests/sec:  31827.68
+Transfer/sec:      4.77MB
+```
+
+**第二次**
+
+```
+$ wrk -t10 -c200 -d30s --latency "http://127.0.0.1:8080/"
+Running 30s test @ http://127.0.0.1:8080/
+  10 threads and 200 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     6.71ms   32.12ms   1.46s    98.13%
+    Req/Sec     6.26k     2.17k   20.15k    78.55%
+  Latency Distribution
+     50%    2.41ms
+     75%    3.20ms
+     90%    8.83ms
+     99%  104.16ms
+  1089621 requests in 30.09s, 163.15MB read
+  Socket errors: connect 0, read 677, write 0, timeout 12
+Requests/sec:  36213.53
+Transfer/sec:      5.42MB
+```
+
+**第三次**
+
+```
+$ wrk -t10 -c200 -d30s --latency "http://127.0.0.1:8080/"
+Running 30s test @ http://127.0.0.1:8080/
+  10 threads and 200 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     5.03ms   22.65ms   1.08s    98.65%
+    Req/Sec     6.57k     1.48k   17.88k    84.77%
+  Latency Distribution
+     50%    2.34ms
+     75%    3.06ms
+     90%    7.45ms
+     99%   32.43ms
+  1602715 requests in 30.06s, 239.97MB read
+  Socket errors: connect 0, read 293, write 0, timeout 2
+Requests/sec:  53309.87
+Transfer/sec:      7.98MB
+```
+
+**第四次**
+
+```
+$ wrk -t10 -c200 -d30s --latency "http://127.0.0.1:8080/"
+Running 30s test @ http://127.0.0.1:8080/
+  10 threads and 200 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     5.64ms   24.97ms 921.84ms   98.25%
+    Req/Sec     6.41k     1.84k   24.40k    80.59%
+  Latency Distribution
+     50%    2.38ms
+     75%    3.33ms
+     90%    8.57ms
+     99%   41.99ms
+  1514888 requests in 30.08s, 226.82MB read
+  Socket errors: connect 0, read 305, write 0, timeout 2
+Requests/sec:  50363.95
+Transfer/sec:      7.54MB
+```

--- a/springboot_undertow/src/main/resources/application.yaml
+++ b/springboot_undertow/src/main/resources/application.yaml
@@ -1,0 +1,21 @@
+spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+      - org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+      - org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration
+      - org.springframework.boot.autoconfigure.mail.MailSenderAutoConfiguration
+      - org.springframework.boot.autoconfigure.jms.JmsAutoConfiguration
+      - org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration
+      - org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration
+      - org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration
+      - org.springframework.boot.autoconfigure.websocket.servlet.WebSocketServletAutoConfiguration
+      - org.springframework.boot.autoconfigure.session.SessionAutoConfiguration
+      - org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration
+      - org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration
+      - org.springframework.boot.autoconfigure.web.servlet.MultipartAutoConfiguration
+      - org.springframework.boot.autoconfigure.webservices.WebServicesAutoConfiguration
+      - org.springframework.boot.autoconfigure.web.servlet.HttpEncodingAutoConfiguration
+      - org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration
+


### PR DESCRIPTION
对比使用undertow后，solon框架和spring boot 2框架的性能，测试结果与硬件相关，期待有更好硬件的测试结果。下表以spring boot 2的原始版本为基准。

| 框架场景 | QPS最高值 | QPS最低值 |  最高值提升百分比 | 最低值提升百分比 |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| spring boot2基准 | 53309.87 | 31827.68 | - | - |
| solon | 54561.18 | 44010.19 | 2.34% | 38.27% |
| spring boot2 优化 | 54335.43 | 35377.05 | 1.92% | 11.15% |


说明：spring boot2优化，关闭大部分该测试场景下不需要的功能。对齐solon的默认过滤器链，关闭了http encoding和webmvc的处理。

结果分析：

最低值都是第一次，是因为冷启动原因，QPS表现最差。
最高值发生在第三次或者第四次，基本上可以认为是完成了预热、JIT。性能都有了大幅提升。

但是并未达到所说的好几倍。还需要确认是否有其他影响。
